### PR TITLE
Add return-volume correlation indicator

### DIFF
--- a/chartsy-desktop/chartsy-ui-chart-indicators/src/main/java/one/chartsy/ui/chart/indicators/ReturnVolumeCorrelationIndicator.java
+++ b/chartsy-desktop/chartsy-ui-chart-indicators/src/main/java/one/chartsy/ui/chart/indicators/ReturnVolumeCorrelationIndicator.java
@@ -1,0 +1,60 @@
+/* Copyright 2024 Mariusz Bernacki <consulting@didalgo.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package one.chartsy.ui.chart.indicators;
+
+import one.chartsy.core.Range;
+import one.chartsy.data.CandleSeries;
+import one.chartsy.data.DoubleSeries;
+import one.chartsy.financial.ValueIndicatorSupport;
+import one.chartsy.ui.chart.*;
+import one.chartsy.ui.chart.data.VisualRange;
+import one.chartsy.ui.chart.plot.LinePlot;
+import org.openide.util.lookup.ServiceProvider;
+
+import java.awt.*;
+
+/**
+ * Visual representation for {@link one.chartsy.financial.indicators.ReturnVolumeCorrelation}.
+ */
+@ServiceProvider(service = Indicator.class)
+public class ReturnVolumeCorrelationIndicator extends AbstractIndicator {
+
+    @Parameter(name = "Periods")
+    public int periods = one.chartsy.financial.indicators.ReturnVolumeCorrelation.DEFAULT_PERIODS;
+
+    @Parameter(name = "Line Color")
+    public Color color = new Color(0xDB4437);
+
+    @Parameter(name = "Line Style")
+    public Stroke style = BasicStrokes.THIN_SOLID;
+
+    public ReturnVolumeCorrelationIndicator() {
+        super("Return/Volume Correlation");
+    }
+
+    @Override
+    public String getLabel() {
+        return "Ret/Vol Corr (" + periods + ")";
+    }
+
+    @Override
+    public VisualRange getRange(ChartContext cf) {
+        return new VisualRange(Range.of(-1, 1), false);
+    }
+
+    @Override
+    public void calculate() {
+        CandleSeries candles = getDataset();
+        if (candles != null) {
+            DoubleSeries values = ValueIndicatorSupport.calculate(candles,
+                    new one.chartsy.financial.indicators.ReturnVolumeCorrelation(periods));
+            addPlot("Correlation", new LinePlot(values, color, style));
+        }
+    }
+
+    @Override
+    public double[] getStepValues(ChartContext cf) {
+        return new double[] {-1, -0.5, 0, 0.5, 1};
+    }
+}

--- a/chartsy-kernel/chartsy-core/pom.xml
+++ b/chartsy-kernel/chartsy-core/pom.xml
@@ -76,6 +76,11 @@
             <version>${commons.lang.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>${commons.math.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
             <version>2.0.1</version>

--- a/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/financial/indicators/ReturnVolumeCorrelation.java
+++ b/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/financial/indicators/ReturnVolumeCorrelation.java
@@ -1,0 +1,81 @@
+/* Copyright 2024 Mariusz Bernacki <consulting@didalgo.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package one.chartsy.financial.indicators;
+
+import one.chartsy.Candle;
+import one.chartsy.data.structures.RingBuffer;
+import one.chartsy.financial.AbstractCandleIndicator;
+import org.apache.commons.math3.stat.correlation.PearsonsCorrelation;
+import org.apache.commons.math3.util.FastMath;
+
+/**
+ * Computes the rolling Pearson correlation between logarithmic price returns
+ * and logarithmic volume ratios.
+ *
+ * <p>The indicator first transforms price closes and volumes into
+ * first‑order differences expressed as natural logarithms:
+ * {@code log(close_t / close_{t-1})} and {@code log(volume_t / volume_{t-1})}.
+ * The correlation is then evaluated over a sliding window of the most recent
+ * {@code periods} observations.
+ */
+public class ReturnVolumeCorrelation extends AbstractCandleIndicator {
+
+    /** Default number of periods used for correlation calculation. */
+    public static final int DEFAULT_PERIODS = 30;
+
+    private final int periods;
+    private final RingBuffer.OfDouble returns;
+    private final RingBuffer.OfDouble volumeRatios;
+    private final PearsonsCorrelation pearsons = new PearsonsCorrelation();
+    private Candle previous;
+    private double last = Double.NaN;
+
+    /**
+     * Constructs the indicator with {@link #DEFAULT_PERIODS} look‑back window.
+     */
+    public ReturnVolumeCorrelation() {
+        this(DEFAULT_PERIODS);
+    }
+
+    /**
+     * Constructs the indicator with a custom look‑back window.
+     *
+     * @param periods number of periods over which the correlation is computed
+     */
+    public ReturnVolumeCorrelation(int periods) {
+        if (periods <= 1)
+            throw new IllegalArgumentException("Periods must be greater than 1");
+        this.periods = periods;
+        this.returns = new RingBuffer.OfDouble(periods);
+        this.volumeRatios = new RingBuffer.OfDouble(periods);
+    }
+
+    @Override
+    public void accept(Candle candle) {
+        if (previous != null) {
+            double prevClose = previous.close();
+            double prevVolume = previous.volume();
+            double close = candle.close();
+            double volume = candle.volume();
+            if (prevClose > 0 && close > 0 && prevVolume > 0 && volume > 0) {
+                double r = FastMath.log(close / prevClose);
+                double v = FastMath.log(volume / prevVolume);
+                returns.add(r);
+                volumeRatios.add(v);
+                last = isReady() ? pearsons.correlation(returns.toPrimitiveArray(), volumeRatios.toPrimitiveArray()) : Double.NaN;
+            }
+        }
+        previous = candle;
+    }
+
+    @Override
+    public double getLast() {
+        return last;
+    }
+
+    @Override
+    public boolean isReady() {
+        return returns.length() == periods;
+    }
+}


### PR DESCRIPTION
## Summary
- add ReturnVolumeCorrelation indicator computing rolling log-return/volume correlation
- expose indicator in UI with configurable period and style
- include Apache Commons Math dependency for statistical correlation

## Testing
- `mvn -q -f chartsy-kernel/chartsy-core/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*
- `mvn -q -f chartsy-desktop/chartsy-ui-chart-indicators/pom.xml test` *(fails: Unresolveable build extension nbm-maven-plugin:4.8)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e6cb4fe08322b13db035355ac211