### PR TITLE
Add Continuation Index indicator and visualization

### DIFF
--- a/chartsy-desktop/chartsy-ui-chart-indicators/src/main/java/one/chartsy/ui/chart/indicators/ContinuationIndexIndicator.java
+++ b/chartsy-desktop/chartsy-ui-chart-indicators/src/main/java/one/chartsy/ui/chart/indicators/ContinuationIndexIndicator.java
@@ -1,0 +1,74 @@
+package one.chartsy.ui.chart.indicators;
+
+import one.chartsy.core.Range;
+import one.chartsy.data.CandleSeries;
+import one.chartsy.data.DoubleSeries;
+import one.chartsy.financial.ValueIndicatorSupport;
+import one.chartsy.financial.indicators.ContinuationIndex;
+import one.chartsy.ui.chart.*;
+import one.chartsy.ui.chart.data.VisualRange;
+import one.chartsy.ui.chart.plot.HorizontalLinePlot;
+import one.chartsy.ui.chart.plot.LinePlot;
+import org.openide.util.lookup.ServiceProvider;
+
+import java.awt.Color;
+import java.awt.Stroke;
+
+/**
+ * Visual representation of the {@link ContinuationIndex} indicator.
+ */
+@ServiceProvider(service = Indicator.class)
+public class ContinuationIndexIndicator extends AbstractIndicator {
+
+    @Parameter(name = "Gamma")
+    public double gamma = 0.8;
+
+    @Parameter(name = "Order")
+    public int order = 8;
+
+    @Parameter(name = "Length")
+    public int length = 40;
+
+    @Parameter(name = "Line Color")
+    public Color lineColor = new Color(0x00695C);
+
+    @Parameter(name = "Line Style")
+    public Stroke lineStyle = BasicStrokes.THIN_SOLID;
+
+    @Parameter(name = "Zero Line Color")
+    public Color zeroLineColor = Color.GRAY;
+
+    @Parameter(name = "Zero Line Style")
+    public Stroke zeroLineStyle = BasicStrokes.ULTRATHIN_DOTTED;
+
+    public ContinuationIndexIndicator() {
+        super("Continuation Index");
+    }
+
+    @Override
+    public String getLabel() {
+        return "CI(" + gamma + ", " + order + ", " + length + ")";
+    }
+
+    @Override
+    public VisualRange getRange(ChartContext cf) {
+        return new VisualRange(Range.of(-1.0, 1.0), false);
+    }
+
+    @Override
+    public void calculate() {
+        CandleSeries candles = getDataset();
+        if (candles != null) {
+            DoubleSeries closes = candles.closes();
+            DoubleSeries result = ValueIndicatorSupport.calculate(closes, new ContinuationIndex(gamma, order, length));
+            addPlot("CI", new LinePlot(result, lineColor, lineStyle));
+            addPlot("Zero", new HorizontalLinePlot(0.0, zeroLineColor, zeroLineStyle));
+        }
+    }
+
+    @Override
+    public double[] getStepValues(ChartContext cf) {
+        return new double[] {-1.0, -0.5, 0.0, 0.5, 1.0};
+    }
+}
+

--- a/chartsy-kernel/chartsy-core/pom.xml
+++ b/chartsy-kernel/chartsy-core/pom.xml
@@ -76,6 +76,11 @@
             <version>${commons.lang.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>${commons.math.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
             <version>2.0.1</version>

--- a/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/financial/indicators/ContinuationIndex.java
+++ b/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/financial/indicators/ContinuationIndex.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 Mariusz Bernacki <consulting@didalgo.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package one.chartsy.financial.indicators;
+
+import one.chartsy.data.structures.DoubleWindowSummaryStatistics;
+import one.chartsy.financial.AbstractDoubleIndicator;
+import org.apache.commons.math3.util.FastMath;
+
+/**
+ * Continuation Index indicator providing early indication of trend onset and exhaustion.
+ *
+ * <p>The indicator is based on the difference between an {@link UltimateSmoother}
+ * filter and a Laguerre filter. The difference is normalized by its average absolute
+ * deviation and compressed using an inverse Fisher transform to produce values
+ * oscillating around +1 and -1.</p>
+ *
+ * <p>Implementation inspired by John F. Ehlers' article "The Continuation Index" in
+ * <i>Stocks & Commodities</i> (September 2025).</p>
+ */
+public class ContinuationIndex extends AbstractDoubleIndicator {
+
+    private final int length;
+    private final UltimateSmoother smoother;
+    private final LaguerreFilter laguerre;
+    private final DoubleWindowSummaryStatistics diffStats;
+    private double last = Double.NaN;
+
+    /**
+     * Creates a new Continuation Index indicator.
+     *
+     * @param gamma  smoothing factor of the Laguerre filter (0 &le; gamma &lt; 1)
+     * @param order  order of the Laguerre filter (typically 1..10)
+     * @param length smoothing length controlling responsiveness
+     */
+    public ContinuationIndex(double gamma, int order, int length) {
+        this.length = length;
+        this.smoother = new UltimateSmoother(Math.max(1, length / 2));
+        this.laguerre = new LaguerreFilter(gamma, order, length);
+        this.diffStats = new DoubleWindowSummaryStatistics(length);
+    }
+
+    @Override
+    public void accept(double price) {
+        double us = smoother.smooth(price);
+        double lg = laguerre.filter(price);
+        double diff = us - lg;
+        diffStats.add(FastMath.abs(diff));
+        double avgDiff = diffStats.getAverage();
+        double ref = (avgDiff != 0.0) ? 2.0 * diff / avgDiff : 0.0;
+        last = FastMath.tanh(ref);
+    }
+
+    @Override
+    public double getLast() {
+        return last;
+    }
+
+    @Override
+    public boolean isReady() {
+        return diffStats.getCount() >= length;
+    }
+
+    /**
+     * The Laguerre filter implementation used by the Continuation Index.
+     */
+    static class LaguerreFilter {
+        private final int order;
+        private final double gamma;
+        private final UltimateSmoother smoother;
+        private final double[] curr;
+        private final double[] prev;
+        private double last = Double.NaN;
+
+        LaguerreFilter(double gamma, int order, int length) {
+            if (gamma < 0.0 || gamma >= 1.0)
+                throw new IllegalArgumentException("gamma must be in [0,1)");
+            if (order < 1)
+                throw new IllegalArgumentException("order must be >= 1");
+            this.gamma = gamma;
+            this.order = order;
+            this.smoother = new UltimateSmoother(length);
+            this.curr = new double[order + 1];
+            this.prev = new double[order + 1];
+        }
+
+        double filter(double price) {
+            // Shift previous values
+            System.arraycopy(curr, 0, prev, 0, curr.length);
+            // Compute Laguerre components
+            for (int i = 2; i <= order; i++) {
+                curr[i] = -gamma * prev[i - 1] + prev[i - 1] + gamma * prev[i];
+            }
+            curr[1] = smoother.smooth(price);
+            double fir = 0.0;
+            for (int i = 1; i <= order; i++) {
+                fir += curr[i];
+            }
+            last = fir / order;
+            return last;
+        }
+
+        double getLast() {
+            return last;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Continuation Index value indicator leveraging Laguerre and UltimateSmoother filters
- expose Continuation Index in UI with customizable parameters and zero line
- include Apache Commons Math for FastMath utilities in core

## Testing
- `mvn -q -pl chartsy-kernel/chartsy-core,chartsy-desktop/chartsy-ui-chart-indicators -am test` *(fails: Unresolveable build extension nbm-maven-plugin)*
- `mvn -q -f chartsy-kernel/chartsy-core/pom.xml test` *(fails: maven-resources-plugin could not be resolved)*


------
https://chatgpt.com/codex/tasks/task_e_68a252342e4c83228a5ae39ec05488c8