### PR TITLE
Add ResourcePaths utility for classpath resource handling

### DIFF
--- a/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/core/io/ResourcePaths.java
+++ b/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/core/io/ResourcePaths.java
@@ -15,13 +15,11 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 /**
- * Utility methods for working with classpath resources as {@link Path Paths}.
+ * Utility methods for working with classpath resources.
  */
 public final class ResourcePaths {
 
-    private ResourcePaths() {
-        // utility class
-    }
+    private ResourcePaths() { }
 
     /**
      * Resolves the given resource name to a {@link Path}.

--- a/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/core/io/ResourcePaths.java
+++ b/chartsy-kernel/chartsy-core/src/main/java/one/chartsy/core/io/ResourcePaths.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Mariusz Bernacki <consulting@didalgo.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package one.chartsy.core.io;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Utility methods for working with classpath resources as {@link Path Paths}.
+ */
+public final class ResourcePaths {
+
+    private ResourcePaths() {
+        // utility class
+    }
+
+    /**
+     * Resolves the given resource name to a {@link Path}.
+     * <p>If the resource is available as a regular file on the filesystem, its
+     * path is returned directly. Otherwise, the resource is copied to a
+     * temporary file which is returned.
+     *
+     * @param resourceName the resource name, optionally prefixed with '/'
+     * @return a path to the resource contents
+     * @throws IOException if the resource cannot be resolved
+     */
+    public static Path pathToResource(String resourceName) throws IOException {
+        String name = resourceName.startsWith("/") ? resourceName.substring(1) : resourceName;
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        URL url = cl.getResource(name);
+        if (url == null)
+            throw new FileNotFoundException("Resource not found on classpath: " + name);
+
+        try {
+            URI uri = url.toURI();
+            if ("file".equalsIgnoreCase(uri.getScheme()))
+                return Paths.get(uri);
+        } catch (Exception ignore) {
+            // fall through to copy-from-stream
+        }
+
+        try (InputStream in = cl.getResourceAsStream(name)) {
+            if (in == null)
+                throw new FileNotFoundException("Resource stream is null: " + name);
+
+            String fileName = Paths.get(name).getFileName().toString();
+            Path tmp = Files.createTempFile("res-", "-" + fileName);
+            Files.copy(in, tmp, StandardCopyOption.REPLACE_EXISTING);
+            tmp.toFile().deleteOnExit();
+            return tmp;
+        }
+    }
+}

--- a/chartsy-kernel/chartsy-core/src/test/java/one/chartsy/core/io/ResourcePathsTest.java
+++ b/chartsy-kernel/chartsy-core/src/test/java/one/chartsy/core/io/ResourcePathsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Mariusz Bernacki <consulting@didalgo.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package one.chartsy.core.io;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourcePathsTest {
+
+    @Test
+    void pathToResource_resolves_existing_resource() throws Exception {
+        Path path = ResourcePaths.pathToResource("test-resource.txt");
+        assertTrue(Files.exists(path));
+        assertEquals("test resource content", Files.readString(path).trim());
+    }
+
+    @Test
+    void pathToResource_handles_leading_slash() throws Exception {
+        Path path = ResourcePaths.pathToResource("/test-resource.txt");
+        assertTrue(Files.exists(path));
+    }
+
+    @Test
+    void pathToResource_throws_when_missing() {
+        assertThrows(FileNotFoundException.class, () -> ResourcePaths.pathToResource("missing-resource.txt"));
+    }
+}

--- a/chartsy-kernel/chartsy-core/src/test/resources/test-resource.txt
+++ b/chartsy-kernel/chartsy-core/src/test/resources/test-resource.txt
@@ -1,0 +1,1 @@
+test resource content

--- a/chartsy-samples/src/main/java/one/chartsy/samples/algorithm/bitcoin/RunBtcBacktest.java
+++ b/chartsy-samples/src/main/java/one/chartsy/samples/algorithm/bitcoin/RunBtcBacktest.java
@@ -33,6 +33,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static one.chartsy.core.io.ResourcePaths.pathToResource;
+
 public class RunBtcBacktest {
 
     public static void main(String[] args) throws Exception {
@@ -110,33 +112,6 @@ public class RunBtcBacktest {
         public void onOrderFilled(Order.Filled fill) {
             super.onOrderFilled(fill);
             //System.out.println("Order filled: " + fill);
-        }
-    }
-
-    public static Path pathToResource(String resourceName) throws IOException {
-        String name = resourceName.startsWith("/") ? resourceName.substring(1) : resourceName;
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        URL url = cl.getResource(name);
-        if (url == null) {
-            throw new FileNotFoundException("Resource not found on classpath: " + name);
-        }
-        try {
-            URI uri = url.toURI();
-            if ("file".equalsIgnoreCase(uri.getScheme()))
-                return Paths.get(uri);
-        } catch (Exception ignore) {
-            // fall through to copy-from-stream
-        }
-
-        try (InputStream in = cl.getResourceAsStream(name)) {
-            if (in == null)
-                throw new FileNotFoundException("Resource stream is null: " + name);
-
-            String fileName = Paths.get(name).getFileName().toString();
-            Path tmp = Files.createTempFile("res-", "-" + fileName);
-            Files.copy(in, tmp, StandardCopyOption.REPLACE_EXISTING);
-            tmp.toFile().deleteOnExit();
-            return tmp;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add ResourcePaths utility to convert classpath resources into `Path`
- test resolution of classpath resources and error handling

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f14bcdd48322a2202df5e3646828